### PR TITLE
Allow 1–3 version components

### DIFF
--- a/syntax/carthage.vim
+++ b/syntax/carthage.vim
@@ -11,7 +11,7 @@ endif
 syntax keyword carthageKeyword git github
 
 " Version numbers
-syn match carthageNumber '\v\d+\.\d+\.\d+'
+syn match carthageNumber '\v\d+(\.\d+){,2}'
 
 " Comments
 syntax match carthageComment "\v#.*$"


### PR DESCRIPTION
Thanks for writing this syntax highlighter! :heart_eyes: 

This change permits versions in any of these forms: `1`, `1.2`, `1.2.3` (since Carthage isn't restricted to triplets).
