### PR TITLE
Fix match pattern in operator

### DIFF
--- a/syntax/carthage.vim
+++ b/syntax/carthage.vim
@@ -18,7 +18,7 @@ syntax match carthageComment "\v#.*$"
 
 " Operators
 syntax match carthageOperator "\v\>\="
-syntax match carthageOperator "\v\~>"
+syntax match carthageOperator "\v\~\>"
 syntax match carthageOperator "\v\=\="
 
 " Strings (version numbers, tags, etc.)


### PR DESCRIPTION
Hi, I found the pattern that the operator is not syntax highlighting and fixed it.

Before:
![before](https://user-images.githubusercontent.com/221802/59498206-e69e0180-8ecf-11e9-8eaf-5576e37c49c7.png)

After:
![after](https://user-images.githubusercontent.com/221802/59498255-033a3980-8ed0-11e9-97c8-c438bf0d3f6a.png)

This plugin is useful for programmers who love iOS and Vim. Thank you for the maintenance.